### PR TITLE
Fixes error handling for broken TSIG keys.

### DIFF
--- a/binder/models.py
+++ b/binder/models.py
@@ -1,6 +1,7 @@
 ### Binder Models
 
 # Standard Imports
+import binascii
 import socket
 import urllib2
 
@@ -38,11 +39,9 @@ class Key(models.Model):
             return None
 
         try:
-            keyring = dns.tsigkeyring.from_text({
-                    self.name : self.data
-                    })
+            keyring = dns.tsigkeyring.from_text({self.name: self.data})
         except binascii.Error, err:
-            raise exceptions.KeyringException("Incorrect key data. Verify key: %s. Reason: %s" % (key_name, err))
+            raise exceptions.KeyringException("Incorrect key data. Verify key: %s. Reason: %s" % (self.name, err))
 
         return keyring
 


### PR DESCRIPTION
The error handling for broken TSIG keys wasn't working for two reasons:
* The import of ```binascii``` has been missing, producing a ```NameError``` once an
  exception occured
* The exception handler was refering to a non-existant variable ```key_name```.

This commit fixes both issues.