### PR TITLE
Fix binder to work with TSIG keys not using dnspythons default algorithm

### DIFF
--- a/binder/helpers.py
+++ b/binder/helpers.py
@@ -85,16 +85,19 @@ def delete_record(dns_server, rr_list, key_name):
 
     try:
         transfer_key = models.Key.objects.get(name=key_name)
-        keyring = transfer_key.create_keyring()
     except models.Key.DoesNotExist:
         keyring = None
+        algorithm = None
+    else:
+        keyring = transfer_key.create_keyring()
+        algorithm = transfer_key.algorithm
 
     delete_response = []
     for current_rr in rr_list:
         record_list = current_rr.split(".")
         record = record_list[0]
         domain = ".".join(record_list[1:])
-        dns_update = dns.update.Update(domain, keyring = keyring)
+        dns_update = dns.update.Update(domain, keyring=keyring, keyalgorithm=algorithm)
         dns_update.delete(record)
         output = send_dns_update(dns_update, dns_server, key_name)
 
@@ -108,11 +111,14 @@ def create_update(dns_server, zone_name, record_name, record_type, record_data, 
 
     try:
         transfer_key = models.Key.objects.get(name=key_name)
-        keyring = transfer_key.create_keyring()
     except models.Key.DoesNotExist:
         keyring = None
+        algorithm = None
+    else:
+        keyring = transfer_key.create_keyring()
+        algorithm = transfer_key.algorithm
 
-    dns_update = dns.update.Update(zone_name, keyring = keyring)
+    dns_update = dns.update.Update(zone_name, keyring=keyring, keyalgorithm=algorithm)
     dns_update.replace(record_name, ttl, record_type, record_data)
     output = send_dns_update(dns_update, dns_server, key_name)
 

--- a/binder/models.py
+++ b/binder/models.py
@@ -88,12 +88,15 @@ class BindServer(models.Model):
 
         try:
             transfer_key = Key.objects.get(name=self.default_transfer_key)
-            keyring = transfer_key.create_keyring()
         except Key.DoesNotExist:
             keyring = None
+            algorithm = None
+        else:
+            keyring = transfer_key.create_keyring()
+            algorithm = transfer_key.algorithm
 
         try:
-            zone = dns.zone.from_xfr(dns.query.xfr(self.hostname, zone_name, keyring=keyring))
+            zone = dns.zone.from_xfr(dns.query.xfr(self.hostname, zone_name, keyring=keyring, keyalgorithm=algorithm))
         except dns.tsig.PeerBadKey:
             # The incorrect TSIG key was selected for transfers.
             raise exceptions.TransferException("Unable to list zone records because of a TSIG key mismatch.")


### PR DESCRIPTION
```binder``` has been broken to work with signatures created with anything but dnspythons default TSIG algorithm, which currently is ```HMAC-MD5```.
This commit fixes that by properly using the algorithm stored for the key.