### PR TITLE
Automatically select the default key for the current server when doing actions.

### DIFF
--- a/binder/templates/base.htm
+++ b/binder/templates/base.htm
@@ -28,8 +28,7 @@
       <div class="navbar">
         <div class="navbar-inner">
           <a class="brand" href="#">
-            {% block pageheader %}
-            {% endblock pageheader %}
+            {% block pageheader %}{% endblock pageheader %}
           </a>
         </div>
       </div>

--- a/binder/templates/bcommon/add_cname_record_form.htm
+++ b/binder/templates/bcommon/add_cname_record_form.htm
@@ -54,7 +54,7 @@
     <div class="controls">
       <select name="key_name">
     {% for key in tsig_keys %}
-        <option value="{{key.id}}"{% if current_key == dns_server.default_transfer_key %} selected="selected"{% endif %}>{{key}}</option>
+        <option value="{{key.id}}"{% if key == dns_server.default_transfer_key %} selected="selected"{% endif %}>{{key}}</option>
     {% empty %}
         <option selected="selected" value=""></option>
     {% endfor %}

--- a/binder/templates/bcommon/add_cname_record_form.htm
+++ b/binder/templates/bcommon/add_cname_record_form.htm
@@ -1,8 +1,6 @@
 {% extends "base.htm" %}
 
-{% block pageheader %}
-Add CNAME record for {{ originating_record }}
-{% endblock pageheader %}
+{% block pageheader %}Add CNAME record for {{ originating_record }}{% endblock pageheader %}
 
 {% block body %}
 <form class="form-horizontal" action="/add_cname_record/result/" method="post">{% csrf_token %}
@@ -10,8 +8,8 @@ Add CNAME record for {{ originating_record }}
   <div class="control-group">
     <label class="control-label">DNS Server: </label>
     <div class="controls">
-      <span class="input-xlarge uneditable-input">{{dns_server}}</span>
-      <input type="hidden" name="dns_server" value="{{dns_server}}"/>
+      <span class="input-xlarge uneditable-input">{{dns_server.hostname}}</span>
+      <input type="hidden" name="dns_server" value="{{dns_server.hostname}}"/>
     </div>
   </div>
 
@@ -27,8 +25,8 @@ Add CNAME record for {{ originating_record }}
     <label class="control-label">CNAME: </label>
     <div class="controls">
       <div class="input-append">
-	      <input class="span2" size="100" name="cname" type="text"><span class="add-on">.{{zone_name}}</span>
-	      <input type="hidden" name="zone_name" value="{{zone_name}}"/>
+        <input class="span2" size="100" name="cname" type="text"><span class="add-on">.{{zone_name}}</span>
+        <input type="hidden" name="zone_name" value="{{zone_name}}"/>
       </div>
       {% if form_errors.cname  %}
       <div class="alert alert-error">
@@ -43,7 +41,7 @@ Add CNAME record for {{ originating_record }}
     <div class="controls">
       <select name="ttl">
         {% for ttl, description in ttl_choices %}
-	    <option value="{{ttl}}">
+        <option value="{{ttl}}">
         {{ttl}} ({{description}})
       </option>
         {% endfor %}
@@ -55,15 +53,15 @@ Add CNAME record for {{ originating_record }}
     <label class="control-label">TSIG Key: </label>
     <div class="controls">
       <select name="key_name">
-	  <option selected="selected" value=""></option>
-	{% for key in tsig_keys %}
-	  <option value="{{key.id}}">{{key}}</option>
-	{% endfor %}
+    {% for key in tsig_keys %}
+        <option value="{{key.id}}"{% if current_key == dns_server.default_transfer_key %} selected="selected"{% endif %}>{{key}}</option>
+    {% empty %}
+        <option selected="selected" value=""></option>
+    {% endfor %}
       </select>
     </div>
   </div>
 
   <button type="submit" class="btn">Save Changes</button>
 </form>
-
 {% endblock body %}

--- a/binder/templates/bcommon/add_record_form.htm
+++ b/binder/templates/bcommon/add_record_form.htm
@@ -1,28 +1,25 @@
 {% extends "base.htm" %}
 
-{% block pageheader %}
-Add record in {{ zone_name }}
-{% endblock pageheader %}
+{% block pageheader %}Add record in {{ zone_name }}{% endblock pageheader %}
 
 {% block body %}
 <form class="form-horizontal" action="/add_record/result/" method="post">{% csrf_token %}
   <legend>Create Record</legend>
-	<input type="hidden" name="zone_name" value="{{zone_name}}"/>
+    <input type="hidden" name="zone_name" value="{{zone_name}}"/>
 
   <div class="control-group">
     <label class="control-label">DNS Server: </label>
     <div class="controls">
-      <span class="input-xlarge uneditable-input">{{dns_server}}</span>
-      <input type="hidden" name="dns_server" value="{{dns_server}}"/>
+      <span class="input-xlarge uneditable-input">{{dns_server.hostname}}</span>
+      <input type="hidden" name="dns_server" value="{{dns_server.hostname}}"/>
     </div>
   </div>
-
 
   <div class="control-group">
     <label class="control-label">Record Name: </label>
     <div class="controls">
       <div class="input-append">
-	    <input class="span2" size="100" name="record_name" type="text"/><span class="add-on">.{{zone_name}}</span>
+        <input class="span2" size="100" name="record_name" type="text"/><span class="add-on">.{{zone_name}}</span>
       </div>
       {% if form_errors.record_name %}
       <div class="alert alert-error">
@@ -51,7 +48,7 @@ Add record in {{ zone_name }}
     <label class="control-label">Record Data: </label>
     <div class="controls">
       <div class="input-append">
-	    <input class="input-large" size="100" name="record_data" type="text"/>
+        <input class="input-large" size="100" name="record_data" type="text"/>
       </div>
       {% if form_errors.record_data %}
       <div class="alert alert-error">
@@ -66,7 +63,7 @@ Add record in {{ zone_name }}
     <div class="controls">
       <select name="ttl">
         {% for ttl, description in ttl_choices %}
-	    <option value="{{ttl}}">
+        <option value="{{ttl}}">
         {{ttl}} ({{description}})
       </option>
         {% endfor %}
@@ -88,9 +85,10 @@ Add record in {{ zone_name }}
     <label class="control-label">TSIG Key: </label>
     <div class="controls">
       <select name="key_name">
-        <option selected="selected" value=""/>
         {% for key in tsig_keys %}
-          <option value="{{key.id}}">{{key}}</option>
+          <option value="{{key.id}}"{% if key == dns_server.default_transfer_key %} selected="selected"{% endif %}>{{key}}</option>
+        {% empty %}
+          <option selected="selected" value=""/>
         {% endfor %}
       </select>
     </div>
@@ -98,5 +96,4 @@ Add record in {{ zone_name }}
 
   <button type="submit" class="btn">Save Changes</button>
 </form>
-
 {% endblock body %}

--- a/binder/templates/bcommon/delete_record_initial.htm
+++ b/binder/templates/bcommon/delete_record_initial.htm
@@ -1,15 +1,12 @@
 {% extends "base.htm" %}
 
-{% block pageheader %}
-Delete record(s) in {{ zone_name }}
-{% endblock pageheader %}
+{% block pageheader %}Delete record(s) in {{ zone_name }}{% endblock pageheader %}
 
 {% block body %}
-
 <table class="table">
 <form action="/delete_record/result/" method="POST">
   {% csrf_token %}
-  <input type="hidden" name="dns_server" value="{{ dns_server }}" />
+  <input type="hidden" name="dns_server" value="{{ dns_server.hostname }}" />
   <input type="hidden" name="zone_name" value="{{ zone_name }}" />
   <input type="hidden" name="rr_list" value="{{ rr_list }}" />
   <tr>
@@ -17,7 +14,7 @@ Delete record(s) in {{ zone_name }}
   </tr>
   <tr>
     <td>Server</td>
-    <td>{{ dns_server }}</td>
+    <td>{{ dns_server.hostname }}</td>
   </tr>
   <tr>
     <td>Zone</td>
@@ -31,9 +28,10 @@ Delete record(s) in {{ zone_name }}
     <td>Key</td>
     <td>
       <select name="key_name">
-        <option selected="selected" value=""/>
         {% for current_key in tsig_keys %}
-        <option value="{{current_key.id}}">{{current_key}}</option>
+        <option value="{{current_key.id}}"{% if current_key == dns_server.default_transfer_key %} selected="selected"{% endif %}>{{current_key}}</option>
+        {% empty %}
+        <option selected="selected" value=""/>
         {% endfor %}
       </select>
     </td>
@@ -45,5 +43,4 @@ Delete record(s) in {{ zone_name }}
   </tr>
   </form>
 </table>
-
 {% endblock body %}

--- a/binder/templates/bcommon/list_server_zones.htm
+++ b/binder/templates/bcommon/list_server_zones.htm
@@ -1,9 +1,6 @@
 {% extends "base.htm" %}
 
-{% block pageheader %}
-Server Zone List for {{ dns_server }}
-{% endblock pageheader %}
-
+{% block pageheader %}Server Zone List for {{ dns_server.hostname }}{% endblock pageheader %}
 
 {% block body %}
 <table class="table sortable">
@@ -16,7 +13,7 @@ Server Zone List for {{ dns_server }}
   {% for current_view, cv_data in cz_data.iteritems %}
     <tr>
       <td>
-        <a href="{% url "zone_list" dns_server=dns_server zone_name=current_zone %}"> {{ current_zone }}</a>
+        <a href="{% url "zone_list" dns_server=dns_server.hostname zone_name=current_zone %}"> {{ current_zone }}</a>
       </td>
       <td>{{ current_view }}</td>
       <td>{{ cv_data.serial }}</td>
@@ -24,5 +21,4 @@ Server Zone List for {{ dns_server }}
   {% endfor %}
 {% endfor %}
 </table>
-
 {% endblock body %}

--- a/binder/templates/bcommon/list_servers.htm
+++ b/binder/templates/bcommon/list_servers.htm
@@ -1,9 +1,6 @@
 {% extends "base.htm" %}
 
-
-{% block pageheader %}
-Server List
-{% endblock pageheader %}
+{% block pageheader %}Server List{% endblock pageheader %}
 
 {% block body %}
 <table class="table">
@@ -21,5 +18,4 @@ Server List
   </tr>
 {% endfor %}
 </table>
-
 {% endblock body %}

--- a/binder/templates/bcommon/list_zone.htm
+++ b/binder/templates/bcommon/list_zone.htm
@@ -1,11 +1,8 @@
 {% extends "base.htm" %}
 
-{% block pageheader %}
-Zone listing for {{ zone_name }} on {{ dns_server }}
-{% endblock pageheader %}
+{% block pageheader %}Zone listing for {{ zone_name }} on {{ dns_server.hostname }}{% endblock pageheader %}
 
 {% block body %}
-
 {% if not errors %}
 <form action="{% url "delete_record" %}" method="post">{% csrf_token %}
 <table class="table table-hover sortable">
@@ -19,7 +16,7 @@ Zone listing for {{ zone_name }} on {{ dns_server }}
   <th></th>
 </tr>
 
-<input type="hidden" name="dns_server" value="{{ dns_server }}">
+<input type="hidden" name="dns_server" value="{{ dns_server.hostname }}">
 <input type="hidden" name="zone_name" value="{{ zone_name }}">
 {% for current_record in zone_array %}
 <tr>
@@ -32,13 +29,13 @@ Zone listing for {{ zone_name }} on {{ dns_server }}
   <td>
     <div class="btn-toolbar" style="margin: 0;">
       <div class="btn-group">
-	<button class="btn dropdown-toggle" data-toggle="dropdown">Record Actions  <span class="caret"></span></button>
-	<ul class="dropdown-menu">
-	  <li><a href="#">Edit Record (Coming Soon)</a></li>
-	  {% if current_record.rr_type == "A" %}
-	  <li><a href="{% url "add_cname" dns_server=dns_server zone_name=zone_name record_name=current_record.rr_name %}">Add CNAME Pointer</a></li>
-	  {% endif %}
-	</ul>
+        <button class="btn dropdown-toggle" data-toggle="dropdown">Record Actions  <span class="caret"></span></button>
+        <ul class="dropdown-menu">
+          <li><a href="#">Edit Record (Coming Soon)</a></li>
+          {% if current_record.rr_type == "A" %}
+          <li><a href="{% url "add_cname" dns_server=dns_server.hostname zone_name=zone_name record_name=current_record.rr_name %}">Add CNAME Pointer</a></li>
+          {% endif %}
+        </ul>
       </div>
     </div>
   </td>
@@ -47,8 +44,8 @@ Zone listing for {{ zone_name }} on {{ dns_server }}
 
 </table>
 
-<a href="{% url "add_record" dns_server=dns_server zone_name=zone_name %}">Add Record</a>
-<input type="submit" value="Delete Selected"/>
+<a href="{% url "add_record" dns_server=dns_server.hostname zone_name=zone_name %}">Add Record</a>
+<button type="submit" class="btn">Delete Selected</button>
 </form>
 {% endif %}
 {% endblock body %}

--- a/binder/templates/bcommon/response_result.htm
+++ b/binder/templates/bcommon/response_result.htm
@@ -1,9 +1,6 @@
 {% extends "base.htm" %}
 
-
-{% block pageheader %}
-Record Result
-{% endblock pageheader %}
+{% block pageheader %}Record Result{% endblock pageheader %}
 
 {% block body %}
 <table class="table">

--- a/binder/templates/index.htm
+++ b/binder/templates/index.htm
@@ -1,8 +1,6 @@
 {% extends "base.htm" %}
 
-{% block pageheader %}
-Home
-{% endblock pageheader %}
+{% block pageheader %}Home{% endblock pageheader %}
 
 {% block body %}
 

--- a/binder/views.py
+++ b/binder/views.py
@@ -11,6 +11,7 @@ def home_index(request):
     """ List the main index page for Binder. """
     return render(request, "index.htm")
 
+
 def view_server_list(request):
     """ List the DNS servers configured in the database. """
     server_list = models.BindServer.objects.all().order_by("hostname")
@@ -21,53 +22,61 @@ def view_server_list(request):
     return render(request, "bcommon/list_servers.htm",
                   { "server_info" : server_info})
 
+
 def view_server_zones(request, dns_server):
     """ Display the list of DNS zones a particular DNS host provides. """
     errors = ""
     zone_array = {}
     try:
         this_server = models.BindServer.objects.get(hostname=dns_server)
-        zone_array = this_server.list_zones()
     except models.BindServer.DoesNotExist, err:
         errors = "There is no configured server by that name: %s" % dns_server
-    except exceptions.ZoneException, err:
-        errors = "Unable to list server zones. Error: %s" % err
+    else:
+        try:
+            zone_array = this_server.list_zones()
+        except exceptions.ZoneException, err:
+            errors = "Unable to list server zones. Error: %s" % err
 
     return render(request, "bcommon/list_server_zones.htm",
                   { "errors" : errors,
-                    "dns_server" : dns_server,
+                    "dns_server" : this_server,
                     "zone_array" : zone_array})
+
 
 def view_zone_records(request, dns_server, zone_name):
     """ Display the list of records for a particular zone. """
     errors = ""
     zone_array = {}
+    this_server = models.BindServer.objects.get(hostname=dns_server)
     try:
-        this_server = models.BindServer.objects.get(hostname=dns_server)
         zone_array = this_server.list_zone_records(zone_name)
     except exceptions.TransferException, err:
         return render(request, "bcommon/list_zone.htm",
                       { "errors" : err,
                         "zone_name" : zone_name,
-                        "dns_server" : dns_server})
+                        "dns_server" : this_server})
     except models.BindServer.DoesNotExist:
         errors = "Requesting a zone listing for a Bind server that is not configured: %s" % dns_server
 
     return render(request, "bcommon/list_zone.htm",
                   { "zone_array" : zone_array,
-                    "dns_server" : dns_server,
+                    "dns_server" : this_server,
                     "zone_name" : zone_name,
                     "errors" : errors})
 
+
 def view_add_record(request, dns_server, zone_name):
     """ View to provide form to add a DNS record. """
+    this_server = models.BindServer.objects.get(hostname=dns_server)
+
     return render(request, "bcommon/add_record_form.htm",
-                  { "dns_server" : dns_server,
+                  { "dns_server" : this_server,
                     "zone_name" : zone_name,
                     "tsig_keys" : models.Key.objects.all(),
                     "ttl_choices" : local_settings.TTL_CHOICES,
                     "record_type_choices" : local_settings.RECORD_TYPE_CHOICES,
                     })
+
 
 def view_add_record_result(request):
     """ Process the input given to add a DNS record. """
@@ -104,20 +113,27 @@ def view_add_record_result(request):
                       { "errors" : errors,
                         "response" : response })
 
+    dns_server = models.BindServer.objects.get(hostname=request.POST["dns_server"])
+
     return render(request, "bcommon/add_record_form.htm",
-                  { "dns_server" : request.POST["dns_server"],
+                  { "dns_server" : dns_server,
                     "zone_name" : request.POST["zone_name"],
                     "form_errors" : form.errors,
                     "form_data" : request.POST })
 
+
 def view_add_cname_record(request, dns_server, zone_name, record_name):
     """ Process given input to add a CNAME pointer."""
+
+    this_server = models.BindServer.objects.get(hostname=dns_server)
+
     return render(request, "bcommon/add_cname_record_form.htm",
-                  { "dns_server" : dns_server,
+                  { "dns_server" : this_server,
                     "originating_record" : "%s.%s" % (record_name, zone_name),
                     "zone_name" : zone_name,
                     "ttl_choices" : local_settings.TTL_CHOICES,
                     "tsig_keys" : models.Key.objects.all() })
+
 
 def view_add_cname_result(request):
     """ Process input on the CNAME form and provide a response."""
@@ -144,8 +160,10 @@ def view_add_cname_result(request):
                       {"response" : add_cname_response,
                        "errors" : errors })
 
+    dns_server = models.BindServer.objects.get(hostname=request.POST["dns_server"])
+
     return render(request, "bcommon/add_cname_record_form.htm",
-                  { "dns_server" : request.POST["dns_server"],
+                  { "dns_server" : dns_server,
                     "zone_name" : request.POST["zone_name"],
                     "record_name" : request.POST["cname"],
                     "originating_record" : request.POST["originating_record"],
@@ -160,7 +178,7 @@ def view_delete_record(request):
     if request.method == "GET":
         return redirect("/")
 
-    dns_server = request.POST["dns_server"]
+    dns_server = models.BindServer.objects.get(hostname=request.POST["dns_server"])
     zone_name = request.POST["zone_name"]
     rr_list = request.POST.getlist("rr_list")
 


### PR DESCRIPTION
This commit introduces automatic selection of the default TSIG key for all
available actions (add, delete). For enabling that it has been necessary to
provide the whole BindServer object to the template, which caused some
additional changes.

I also took the opportunity to unify some styling (indentation, linebreaks) of
the HTML templates.