### PR TITLE
Makes SECRET_KEY secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pyc
 *.conf
 *~
+/binder/secret.txt

--- a/binder/settings.py
+++ b/binder/settings.py
@@ -42,7 +42,18 @@ MEDIA_ROOT = os.path.join(SITE_ROOT, "files")
 MEDIA_URL = "/files/"
 STATIC_URL= "/static/"
 
-SECRET_KEY = 'iuo-zka8nnv0o+b*7#_*fcep$@f^35=)c#7_20z6i8g0oc&r!g'
+SECRET_FILE = os.path.join(SITE_ROOT, 'secret.txt')
+try:
+    SECRET_KEY = open(SECRET_FILE).read().strip()
+except IOError:
+    try:
+        from random import choice
+        SECRET_KEY = ''.join([choice('abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)') for i in range(50)])
+        secret = file(SECRET_FILE, 'w')
+        secret.write(SECRET_KEY)
+        secret.close()
+    except IOError:
+        Exception('Please create a %s file with random characters to generate your secret key!' % SECRET_FILE)
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (


### PR DESCRIPTION
To quote from Djangos documentation:
> The secret key must be a large random value and it must be kept secret.
https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/#secret-key

This commit achieves that by generating a file containing a random string
when running the first time and by using this string as ```SECRET_KEY``` from then
on.