### PR TITLE
Fixes some problems introduced with 448d18f

### DIFF
--- a/binder/templates/bcommon/add_cname_record_form.htm
+++ b/binder/templates/bcommon/add_cname_record_form.htm
@@ -63,6 +63,6 @@
   </div>
 
   <button type="submit" class="btn">Save Changes</button>
-  <a href="{% url "zone_list" dns_server=dns_server zone_name=zone_name %}">Cancel</a>
+  <a href="{% url "zone_list" dns_server=dns_server zone_name=zone_name %}" class="btn btn-warning">Cancel</a>
 </form>
 {% endblock body %}

--- a/binder/templates/bcommon/add_record_form.htm
+++ b/binder/templates/bcommon/add_record_form.htm
@@ -95,6 +95,6 @@
   </div>
 
   <button type="submit" class="btn">Save Changes</button>
-  <button class="btn btn-warning"><a href="{% url "zone_list" dns_server=dns_server zone_name=zone_name %}">Cancel</a></buton>
+  <a href="{% url "zone_list" dns_server=dns_server zone_name=zone_name %}" class="btn btn-warning">Cancel</a>
 </form>
 {% endblock body %}

--- a/binder/templates/bcommon/delete_record_initial.htm
+++ b/binder/templates/bcommon/delete_record_initial.htm
@@ -39,7 +39,7 @@
   <tr>
     <td colspan="2">
       <button type="submit" class="btn">Yes, I really want to delete them.</button>
-      <button class="btn btn-warning"><a href="{% url "zone_list" dns_server=dns_server zone_name=zone_name %}">Cancel</a></button>
+      <a href="{% url "zone_list" dns_server=dns_server zone_name=zone_name %}" class="btn btn-warning">Cancel</a>
     </td>
   </tr>
   </form>

--- a/binder/templates/bcommon/list_zone.htm
+++ b/binder/templates/bcommon/list_zone.htm
@@ -6,7 +6,7 @@
 {% if not errors %}
 <form action="{% url "delete_record" %}" method="post">{% csrf_token %}
 <table class="table table-hover sortable">
-<button class="btn btn-default"><a href="{% url "add_record" dns_server=dns_server zone_name=zone_name %}">Add Record</a></button>
+<a href="{% url "add_record" dns_server=dns_server zone_name=zone_name %}" class="btn btn-default">Add Record</a></button>
 
 <tr>
   <th>Select</th>


### PR DESCRIPTION
Commit 448d18f8f94e5386f9ec9929e1c15efae28bf7bf introduced some problems, which are fixed in this commit:
* Cancel links were converted to buttons, by simply wrapping them into a
  ```<button>```-element, causing them to act as submit buttons, as submit is the
  default action for buttons, instead of cancel buttons. Instead the proper
  bootstrap code for showing links as buttons is used now.
* ```add_cname_record_form.htm``` hasn't been adjusted to show a button instead of a
  link for cancelling. I converted that to a button now as well.