### PR TITLE
Improved record deletion performance

### DIFF
--- a/binder/templates/bcommon/list_zone.htm
+++ b/binder/templates/bcommon/list_zone.htm
@@ -22,7 +22,7 @@
 <input type="hidden" name="zone_name" value="{{ zone_name }}">
 {% for current_record in zone_array %}
 <tr>
-  <td><input type="checkbox" name="rr_list" value="{{ current_record.rr_name }}.{{ zone_name }}"></td>
+  <td><input type="checkbox" name="rr_list" value="{{ current_record.rr_name }}"></td>
   <td>{{ current_record.rr_name }}</td>
   <td>{{ current_record.rr_ttl }}</td>
   <td>{{ current_record.rr_class }}</td>

--- a/binder/templates/bcommon/response_result.htm
+++ b/binder/templates/bcommon/response_result.htm
@@ -10,7 +10,7 @@
   <th>Output</th>
 </tr>
 <tr>
-  <td>{{ current_response.description }}</td>
+  <td>{{ current_response.description|safe }}</td>
   <td><pre>{{ current_response.output }}</pre></td>
 </tr>
 {% endfor %}

--- a/binder/views.py
+++ b/binder/views.py
@@ -204,6 +204,7 @@ def view_delete_result(request):
         print "in view_delete_result, form errors: %r" % form.errors
 
     delete_result = helpers.delete_record(clean_form["dns_server"],
+                                          clean_form["zone_name"],
                                           clean_form["rr_list"],
                                           clean_form["key_name"])
 


### PR DESCRIPTION
Up to now when selecting multiple resource records for deletion for each of
them a single message has been sent to the DNS server. This commit changes the
behavior to put all requested deletions into a single message, which improves
performance.