### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 env:
   - DJANGO="Django>=1.6,<1.7"
   - DJANGO="Django>=1.7,<1.8"
+  - DJANGO="Django>=1.8,<1.9"
 install:
   - pip install -q $DJANGO
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.7"
+env:
+  - DJANGO="Django>=1.6,<1.7"
+  - DJANGO="Django>=1.7,<1.8"
+install:
+  - pip install -q $DJANGO
+  - pip install -r requirements.txt
+script:
+  - python manage.py test

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,7 @@
 # Binder #
 
+[![Build Status](https://travis-ci.org/jforman/binder.svg?branch=master)](https://travis-ci.org/jforman/binder)
+
 A Django web application for viewing and editing BIND DNS zone records.
 
 Binder supports adding and deleting DNS records (and eventually editing in place). TSIG-authenticated transfers and updates are supported.


### PR DESCRIPTION
To improve the code quality of binder, this commit adds support for continuous integration by using Travis CI (https://travis-ci.org/).
This will ensure that every commit and every pull request will trigger test runs of the tests included in binder, helping to avoid code with broken tests.

To get the integration to run, you'll have to connect your Github account to Travis CI and merge #25 and #26 to avoid failing tests.