### PR TITLE
Fix contents of requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-beautifulsoup4>=4.3
+Django>=1.6
 dnspython>=1.11
 pybindxml>=0.4


### PR DESCRIPTION
* The most important requirement for binder, Django, was missing completely in ```requirements.txt```, so I added it. It's Django 1.6 because the tests don't work with prior versions.
* As already noted in #10 binder doesn't rely on ```beautifulsoup4```, as it's just a dependency of ```pybindxml``` and get's installed together with it. Therefore it shouldn't be part of binders ```requirements.txt```.