### PR TITLE
Clean up of various parts of the templates

### DIFF
--- a/binder/templates/base.html
+++ b/binder/templates/base.html
@@ -3,7 +3,9 @@
 {% block header %}
 <head>
   <title>Binder DNS Admin</title>
-  <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}bootstrap/css/bootstrap.css" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}bootstrap/css/bootstrap.min.css" />
   <script src="{{ STATIC_URL }}sorttable.js"></script>
 </head>
 {% endblock header %}
@@ -27,7 +29,7 @@
   <div class="col-md-10">
     <div class="panel panel-default">
       <div class="panel-heading">
-	{% block pageheader %}{% endblock pageheader %}
+        {% block pageheader %}{% endblock pageheader %}
       </div>
     </div>
 

--- a/binder/templates/bcommon/add_cname_record_form.html
+++ b/binder/templates/bcommon/add_cname_record_form.html
@@ -42,7 +42,7 @@
   </div>
 
   <div class="form-group">
-    <label for="id_ttl" class="control-label col-md-2">TTL</label>
+    <label class="control-label col-md-2">TTL</label>
     <div class="controls col-md-10">
       {% for ttl, description in ttl_choices %}
       <label for="id_ttl_{{ttl}}" class="radio-inline">

--- a/binder/templates/bcommon/add_cname_record_form.html
+++ b/binder/templates/bcommon/add_cname_record_form.html
@@ -45,8 +45,8 @@
     <label for="id_ttl" class="control-label col-md-2">TTL</label>
     <div class="controls col-md-10">
       {% for ttl, description in ttl_choices %}
-      <label class="radio-inline">
-        <input type="radio" id="id_ttl" name="ttl" id="ttl_{{ttl}}" value="{{ttl}}">{{ttl}} ({{description}})
+      <label for="id_ttl_{{ttl}}" class="radio-inline">
+        <input type="radio" id="id_ttl_{{ ttl }}" name="ttl" value="{{ttl}}">{{ttl}} ({{description}})
       </label>
       {% endfor %}
     </div>

--- a/binder/templates/bcommon/add_cname_record_form.html
+++ b/binder/templates/bcommon/add_cname_record_form.html
@@ -6,56 +6,56 @@
 <form class="form-horizontal" action="/add_cname_record/result/" method="post">{% csrf_token %}
   <legend>Create CNAME record</legend>
   <div class="form-group">
-    <label class="control-label col-md-2">DNS Server</label>
+    <label for="id_dns_server" class="control-label col-md-2">DNS Server</label>
     <div class="controls col-md-10">
-      <input type="text" class="form-control" name="dns_server" value="{{dns_server.hostname}}" readonly />
+      <input type="text" id="id_dns_server" class="form-control" name="dns_server" value="{{dns_server.hostname}}" readonly />
     </div>
   </div>
 
   <div class="form-group">
-    <label class="control-label col-md-2">Zone</label>
+    <label for="id_zone_name" class="control-label col-md-2">Zone</label>
     <div class="controls col-md-10">
-      <input type="text" class="form-control" name="zone_name" value="{{zone_name}}" readonly />
+      <input type="text" id="id_zone_name" class="form-control" name="zone_name" value="{{zone_name}}" readonly />
     </div>
   </div>
 
   <div class="form-group">
-    <label class="control-label col-md-2">Originating Record</label>
+    <label for="id_originating_record" class="control-label col-md-2">Originating Record</label>
     <div class="controls col-md-10">
-      <input type="text" class="form-control" name="originating_record" value="{{originating_record}}" readonly />
+      <input type="text" id="id_originating_record" class="form-control" name="originating_record" value="{{originating_record}}" readonly />
     </div>
   </div>
 
   <div class="form-group">
-    <label class="control-label col-md-2">CNAME</label>
+    <label for="id_cname" class="control-label col-md-2">CNAME</label>
     <div class="controls col-md-10">
       {% if form_errors.cname %}
-        <div class="alert alert-danger" role="alert">
-	  Error in CNAME input: {{ form_errors.cname|stringformat:"s"|striptags }} Previous Value: {{ form_data.cname }}
-	</div>
+      <div class="alert alert-danger" role="alert">
+        Error in CNAME input: {{ form_errors.cname|stringformat:"s"|striptags }} Previous Value: {{ form_data.cname }}
+      </div>
       {% endif %}
       <div class="input-group">
-	<input type="text" class="form-control" name="cname"/>
-	<div class="input-group-addon">.{{zone_name}}</div>
+        <input type="text" id="id_originating_record" class="form-control" name="cname"/>
+        <div class="input-group-addon">.{{zone_name}}</div>
       </div>
     </div>
   </div>
 
   <div class="form-group">
-    <label class="control-label col-md-2">TTL</label>
+    <label for="id_ttl" class="control-label col-md-2">TTL</label>
     <div class="controls col-md-10">
       {% for ttl, description in ttl_choices %}
-        <label class="radio-inline">
-          <input type="radio" name="ttl" id="ttl_{{ttl}}" value="{{ttl}}">{{ttl}} ({{description}})
-	</label>
+      <label class="radio-inline">
+        <input type="radio" id="id_ttl" name="ttl" id="ttl_{{ttl}}" value="{{ttl}}">{{ttl}} ({{description}})
+      </label>
       {% endfor %}
     </div>
   </div>
 
   <div class="form-group">
-    <label class="control-label col-md-2">TSIG Key</label>
+    <label for="id_key_name" class="control-label col-md-2">TSIG Key</label>
     <div class="controls col-md-10">
-      <select class="form-control" name="key_name">
+      <select id="id_key_name" class="form-control" name="key_name">
         {% for key in tsig_keys %}
           <option value="{{key.id}}"{% if key == dns_server.default_transfer_key %} selected="selected"{% endif %}>{{key}}</option>
         {% empty %}
@@ -65,7 +65,7 @@
     </div>
   </div>
 
-  <button type="submit" class="btn">Save Changes</button>
+  <button type="submit" class="btn btn-default">Save Changes</button>
 </form>
 
 {% endblock body %}

--- a/binder/templates/bcommon/add_record_form.html
+++ b/binder/templates/bcommon/add_record_form.html
@@ -6,22 +6,22 @@
 <form class="form-horizontal" action="/add_record/result/" method="POST">{% csrf_token %}
   <legend>Create Record</legend>
   <div class="form-group">
-    <label class="control-label col-md-2">DNS Server</label>
+    <label for="id_dns_server" class="control-label col-md-2">DNS Server</label>
     <div class="controls col-md-10">
-      <input type="text" class="form-control" name="dns_server" value="{{dns_server.hostname}}" readonly />
+      <input type="text" id="id_dns_server" class="form-control" name="dns_server" value="{{dns_server.hostname}}" readonly />
     </div>
   </div>
 
   <div class="form-group">
-    <label class="control-label col-md-2">Zone</label>
+    <label for="id_zone_name" class="control-label col-md-2">Zone</label>
     <div class="controls col-md-10">
-      <input type="text" class="form-control" name="zone_name" value="{{zone_name}}" readonly>
+      <input type="text" id="id_zone_name" class="form-control" name="zone_name" value="{{zone_name}}" readonly>
     </div>
   </div>
 
 
   <div class="form-group">
-    <label class="control-label col-md-2">Record Name</label>
+    <label for="id_record_name" class="control-label col-md-2">Record Name</label>
     <div class="controls col-md-10">
       {% if form_errors.record_name %}
       <div class="alert alert-danger" role="alert">
@@ -29,8 +29,8 @@
       </div>
       {% endif %}
       <div class="input-group">
-        <input type="text" class="form-control" name="record_name"/>
-	<div class="input-group-addon">.{{zone_name}}</div>
+        <input type="text" id="id_record_name" class="form-control" name="record_name"/>
+        <div class="input-group-addon">.{{zone_name}}</div>
       </div>
     </div>
   </div>
@@ -40,34 +40,34 @@
     <div class="controls col-md-10">
       {% if "in-addr.arpa" not in zone_name and "ip6.arpa" not in zone_name %}
         {% for type, name in record_type_choices %}
-          <label class="radio-inline">
-	    <input type="radio" name="record_type" id="record_type_{{name}}" value="{{name}}">{{name}}
+          <label for="id_record_type_{{ name }}" class="radio-inline">
+            <input type="radio" id="id_record_type_{{ name }}" name="record_type" id="record_type_{{name}}" value="{{name}}">{{name}}
           </label>
         {% endfor %}
       {% else %}
-	  <label class="radio-inline">
-            <input type="radio" name="record_type" id="record_type_PTR" value="PTR" checked="checked">PTR
+          <label for="id_record_type" class="radio-inline">
+            <input type="radio" id="id_record_type" name="record_type" id="record_type_PTR" value="PTR" checked="checked">PTR
           </label>
       {% endif %}
     </div>
   </div>
 
   <div class="form-group">
-    <label class="control-label col-md-2">Record Data</label>
+    <label for="id_record_data" class="control-label col-md-2">Record Data</label>
     <div class="controls col-md-10">
-	  {% if form_errors.record_data %}
-	  <div class="alert alert-danger" role="alert">
+      {% if form_errors.record_data %}
+      <div class="alert alert-danger" role="alert">
             Record Data: {{ form_errors.record_data|stringformat:"s"|striptags }} Previous Value: {{ form_data.record_data }}
-	  </div>
-	  {% endif %}
-	  <div class="input-group">
-            <input type="text" class="form-control" name="record_data"/>
-	    {% if "in-addr.arpa" not in zone_name and "ip6.arpa" not in zone_name %}
-	    <div class="input-group-addon">IP Address</div>
-	    {% else %}
-	    <div class="input-group-addon">FQDN</div>
-	    {% endif %}
-	  </div>
+      </div>
+      {% endif %}
+      <div class="input-group">
+        <input type="text" id="id_record_data" class="form-control" name="record_data"/>
+        {% if "in-addr.arpa" not in zone_name and "ip6.arpa" not in zone_name %}
+        <div class="input-group-addon">IP Address</div>
+        {% else %}
+        <div class="input-group-addon">FQDN</div>
+        {% endif %}
+      </div>
     </div>
   </div>
   
@@ -75,28 +75,28 @@
     <label class="control-label col-md-2">TTL</label>
     <div class="controls col-md-10">
       {% for ttl, description in ttl_choices %}
-        <label class="radio-inline">
-          <input type="radio" name="ttl" id="ttl_{{ttl}}" value="{{ttl}}">{{ttl}} ({{description}})
-	</label>
+        <label for="id_ttl_{{ ttl }}" class="radio-inline">
+          <input type="radio" id="id_ttl_{{ ttl }}" name="ttl" id="ttl_{{ttl}}" value="{{ttl}}">{{ttl}} ({{description}})
+        </label>
       {% endfor %}
     </div>
   </div>
 
   {% if "in-addr.arpa" not in zone_name and "ip.arpa" not in zone_name %}
   <div class="form-group">
-    <label class="control-label col-md-2">Create PTR?</label>
+    <label for="id_create_reverse" class="control-label col-md-2">Create PTR?</label>
     <div class="checkbox controls col-md-10">
       <label>
-	<input type="checkbox" name="create_reverse" id="create_reverse" value="True" aria-label="create ptr record?">Yes
-      </label>
+        <input type="checkbox" id="id_create_reverse" name="create_reverse" id="create_reverse" value="True" aria-label="create ptr record?">Yes
+      <label>
     </div>
   </div>
   {% endif %}
 
   <div class="form-group">
-    <label class="control-label col-md-2">TSIG Key</label>
+    <label for="id_key_name" class="control-label col-md-2">TSIG Key</label>
     <div class="controls col-md-10">
-      <select class="form-control" name="key_name">
+      <select id="id_key_name" class="form-control" name="key_name">
         {% for key in tsig_keys %}
           <option value="{{key.id}}"{% if key == dns_server.default_transfer_key %} selected="selected"{% endif %}>{{key}}</option>
         {% empty %}
@@ -106,7 +106,7 @@
     </div>
   </div>
 
-  <button type="submit" class="btn">Save Changes</button>
+  <button type="submit" class="btn btn-default">Save Changes</button>
   <a href="{% url "zone_list" dns_server=dns_server zone_name=zone_name %}" class="btn btn-warning">Cancel</a>
 </form>
 {% endblock body %}

--- a/binder/templates/bcommon/add_record_form.html
+++ b/binder/templates/bcommon/add_record_form.html
@@ -41,7 +41,7 @@
       {% if "in-addr.arpa" not in zone_name and "ip6.arpa" not in zone_name %}
         {% for type, name in record_type_choices %}
           <label for="id_record_type_{{ name }}" class="radio-inline">
-            <input type="radio" id="id_record_type_{{ name }}" name="record_type" id="record_type_{{name}}" value="{{name}}">{{name}}
+            <input type="radio" id="id_record_type_{{ name }}" name="record_type" value="{{name}}">{{name}}
           </label>
         {% endfor %}
       {% else %}
@@ -76,7 +76,7 @@
     <div class="controls col-md-10">
       {% for ttl, description in ttl_choices %}
         <label for="id_ttl_{{ ttl }}" class="radio-inline">
-          <input type="radio" id="id_ttl_{{ ttl }}" name="ttl" id="ttl_{{ttl}}" value="{{ttl}}">{{ttl}} ({{description}})
+          <input type="radio" id="id_ttl_{{ ttl }}" name="ttl" value="{{ttl}}">{{ttl}} ({{description}})
         </label>
       {% endfor %}
     </div>

--- a/binder/templates/bcommon/delete_record_initial.html
+++ b/binder/templates/bcommon/delete_record_initial.html
@@ -22,72 +22,29 @@
     </td>
 </tr>
 <tr>
-  <td>TSIG Key</td>
+  <td><label for="id_key_name">TSIG Key</label></td>
   <td>
     <div class="form-group">
       <div class="controls">
-	<select class="form-control" name="key_name">
+        <select id="id_key_name" class="form-control" name="key_name">
           {% for key in tsig_keys %}
           <option value="{{key.id}}"{% if key == dns_server.default_transfer_key %} selected="selected"{% endif %}>{{key}}</option>
           {% empty %}
           <option selected="selected" value=""/>
           {% endfor %}
-	</select>
+        </select>
       </div>
     </div>
   </td>
 </tr>
 <tr>
   <td>
-    <button type="submit" class="btn">Yes, really delete.</button>
+    <button type="submit" class="btn btn-default">Yes, really delete.</button>
   </td>
   <td></td>
 </tr>
 </table>
 
-<!-- <form class="form-horizontal" action="/delete_record/result/" method="POST"> -->
-<!--   {% csrf_token %} -->
-<!--   <legend>Delete Record(s)</legend> -->
-<!--   <div class="form-group"> -->
-<!--    <label class="control-label col-md-2">DNS Server</label> -->
-<!--    <div class="controls col-md-10"> -->
-<!--      <input type="text" class="form-control" name="dns_server" value="{{ dns_server.hostname }}" readonly /> -->
-<!--    </div> -->
-<!--   </div> -->
-
-<!--   <div class="form-group"> -->
-<!--    <label class="control-label col-md-2">Zone Name</label> -->
-<!--    <div class="controls col-md-10"> -->
-<!--      <input type="text" class="form-control" name="zone_name" value="{{ zone_name }}" readonly /> -->
-<!--    </div> -->
-<!--   </div> -->
-
-<!--   <div class="form-group"> -->
-<!--     <label class="control-label col-md-2">Record List</label> -->
-<!--     <div class="controls col-md-10"> -->
-<!--       <select multiple class="form-control" name="rr_list"> -->
-<!-- 	{% for current_rr in rr_list %} -->
-<!-- 	  <option selected value="{{current_rr}}" selected>{{current_rr}}</option> -->
-<!-- 	{% endfor %} -->
-<!--        </select> -->
-<!--     </div> -->
-<!--   </div> -->
-
-<!--   <div class="form-group"> -->
-<!--     <label class="control-label col-md-2">TSIG Key</label> -->
-<!--     <div class="controls col-md-10"> -->
-<!--       <select class="form-control" name="key_name"> -->
-<!--         {% for key in tsig_keys %} -->
-<!--           <option value="{{key.id}}"{% if key == dns_server.default_transfer_key %} selected="selected"{% endif %}>{{key}}</option> -->
-<!--         {% empty %} -->
-<!--           <option selected="selected" value=""/> -->
-<!--         {% endfor %} -->
-<!--       </select> -->
-<!--     </div> -->
-<!--   </div> -->
-
-
-<!--   <button type="submit" class="btn">Yes, really delete.</button> -->
 <input type="text" class="form-control hidden" name="dns_server" value="{{ dns_server.hostname }}"/>
 <input type="text" class="form-control hidden" name="zone_name" value="{{ zone_name }}"/>
 <input type="text" class="form-control hidden" name="rr_list" value="{{ rr_list }}"/>

--- a/binder/templates/bcommon/list_zone.html
+++ b/binder/templates/bcommon/list_zone.html
@@ -4,10 +4,14 @@
 
 {% block body %}
 {% if not errors %}
-<form action="{% url "delete_record" %}" method="post">{% csrf_token %}
-<table class="table table-condensed table-hover sortable">
-<a href="{% url "add_record" dns_server=dns_server zone_name=zone_name %}" class="btn btn-default">Add Record</a></button>
+<a href="{% url "add_record" dns_server=dns_server zone_name=zone_name %}" class="btn btn-default">Add Record</a>
 
+<form action="{% url "delete_record" %}" method="post">{% csrf_token %}
+
+<input type="hidden" name="dns_server" value="{{ dns_server.hostname }}">
+<input type="hidden" name="zone_name" value="{{ zone_name }}">
+
+<table class="table table-condensed table-hover sortable">
 <tr>
   <th>Select</th>
   <th>Name</th>
@@ -18,17 +22,9 @@
   <th></th>
 </tr>
 
-<input type="hidden" name="dns_server" value="{{ dns_server.hostname }}">
-<input type="hidden" name="zone_name" value="{{ zone_name }}">
 {% for current_record in zone_array %}
 <tr>
-  <td>
-    <div class="checkbox">
-      <label>
-	<input type="checkbox" id="rr_{{current_record.rr_name}}" name="rr_list" value="{{ current_record.rr_name }}.{{ zone_name }}"/>
-     </label>
-  </div>
-  </td>
+  <td><input type="checkbox" id="rr_{{current_record.rr_name}}" name="rr_list" value="{{ current_record.rr_name }}.{{ zone_name }}" /></td>
   <td>{{ current_record.rr_name }}</td>
   <td>{{ current_record.rr_ttl }}</td>
   <td>{{ current_record.rr_class }}</td>
@@ -37,7 +33,7 @@
   <td>
     <div class="btn-toolbar" style="margin: 0;">
       <div class="btn-group">
-        <button class="btn dropdown-toggle" data-toggle="dropdown">Record Actions  <span class="caret"></span></button>
+        <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">Record Actions <span class="caret"></span></button>
         <ul class="dropdown-menu">
           <li><a href="#">Edit Record (Coming Soon)</a></li>
           {% if current_record.rr_type == "A" %}


### PR DESCRIPTION
* Replaced tabs for indentation with proper spaces to have only spaces for
  indentation
* Added the ```btn-default``` class to all buttons where it was missing
* Added relations between labels and the elements they are labeling using the
  naming schema Django uses by default (might become handy in the future)
* Added additional meta tags required by Bootstrap 3
* Moved the button for adding records in ```list_zone.html``` out of the table to get
  cleaner markup
* Swapped out the used version of Bootstrap against the minified one.
* Removed the commented out old code from ```delete_record_initial.html```, because
  that's why we have version control