### PR TITLE
Fixes missing cancel buttons

### DIFF
--- a/binder/templates/bcommon/add_cname_record_form.html
+++ b/binder/templates/bcommon/add_cname_record_form.html
@@ -66,6 +66,7 @@
   </div>
 
   <button type="submit" class="btn">Save Changes</button>
+  <a href="{% url "zone_list" dns_server=dns_server zone_name=zone_name %}" class="btn btn-warning">Cancel</a>
 </form>
 
 {% endblock body %}

--- a/binder/templates/bcommon/delete_record_initial.html
+++ b/binder/templates/bcommon/delete_record_initial.html
@@ -40,6 +40,7 @@
 <tr>
   <td>
     <button type="submit" class="btn">Yes, really delete.</button>
+    <a href="{% url "zone_list" dns_server=dns_server zone_name=zone_name %}" class="btn btn-warning">Cancel</a>
   </td>
   <td></td>
 </tr>


### PR DESCRIPTION
The cancel buttons on the forms introduced with 1671bc4c2ffba499c086d4298c986074494f6e40 vanished with 41f78b3effcf89975c522b4791151233ece9e17e.
This commit adds them back.