### PR TITLE
Adds support for Django 1.9 while dropping support for unsupported versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: python
 python:
   - "2.7"
 env:
-  - DJANGO="Django>=1.6,<1.7"
-  - DJANGO="Django>=1.7,<1.8"
   - DJANGO="Django>=1.8,<1.9"
+  - DJANGO="Django>=1.9,<1.10"
 install:
   - pip install -q $DJANGO
   - pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,29 +4,20 @@ MAINTAINER Jeffrey Forman <code@jeffreyforman.net>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
-    python-bs4 \
-    python-dev \
-    python-django \
-    python-dnspython \
-    python-lxml \
-    python-pip \
-    python-sqlite 
+    python-pip
 
-RUN pip install \
-    pybindxml
+RUN git clone https://github.com/jforman/binder.git /opt/binder/
 
-WORKDIR /opt
+RUN pip install -r /opt/binder/requirements.txt
 
-RUN git clone https://github.com/jforman/binder.git
+ENV	PYTHONPATH $PYTHONPATH:/opt/binder
+ENV	DJANGO_SETTINGS_MODULE binder.settings
 
-env	PYTHONPATH $PYTHONPATH:/opt/binder
-env	DJANGO_SETTINGS_MODULE binder.settings
+RUN ["/opt/binder/manage.py", "migrate"]
+RUN ["/opt/binder/manage.py", "loaddata", "/opt/binder/binder/fixtures/initial_data.json"]
 
-run ["/opt/binder/manage.py", "migrate"]
-run ["/opt/binder/manage.py", "loaddata", "/opt/binder/binder/fixtures/initial_data.json"]
-
-expose :8000
+EXPOSE :8000
 
 CMD ["/opt/binder/manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ Binder supports adding and deleting DNS records (and eventually editing in place
 
 Packages:
 
-* [Django](http://www.djangoproject.com)
+* [Django](http://www.djangoproject.com) >=1.8
 * Python Modules
   * [pybindxml](https://pypi.python.org/pypi?name=pybindxml&:action=display): This is a shared library I wrote to scrape and stick into Python dict objects various server/zone data from a BIND DNS server.
   * Beautifulsoup4: This library is included as a dependency of pybindmlx when you  when you install pybindxml.
@@ -42,7 +42,7 @@ binder/
 
 The development server is run as most Django dev servers are run.
 
-    /opt/binder/manage.py syncdb
+    /opt/binder/manage.py migrate
     /opt/binder/manage.py runserver
 
 Once you have the Django server up and running, you will want to configure at least one BIND server in the Django Admin app. This includes a hostname, TCP statistics port and a default TSIG transfer key to be used when doing AXFR actions (if necessary).

--- a/binder/settings.py
+++ b/binder/settings.py
@@ -4,7 +4,6 @@ from django.contrib.messages import constants as messages
 
 SITE_ROOT = os.path.dirname(os.path.realpath(__file__))
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@domain.com'),
@@ -56,11 +55,25 @@ except IOError:
     except IOError:
         Exception('Please create a %s file with random characters to generate your secret key!' % SECRET_FILE)
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'DIRS': os.path.join(SITE_ROOT, "templates"),
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages'
+                ],
+            'debug': True
+            }
+    }
+]
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -72,10 +85,6 @@ MIDDLEWARE_CLASSES = (
 )
 
 ROOT_URLCONF = 'binder.urls'
-
-TEMPLATE_DIRS = (
-    os.path.join(SITE_ROOT, "templates"),
-)
 
 INSTALLED_APPS = (
     'django.contrib.contenttypes',

--- a/binder/templates/registration/login.html
+++ b/binder/templates/registration/login.html
@@ -1,8 +1,9 @@
+{% load static from staticfiles %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
 <title>Binder DNS Admin – Login</title>
-<link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}bootstrap/css/bootstrap.css" />
+<link rel="stylesheet" type="text/css" href="{% static "bootstrap/css/bootstrap.css" %}" />
 </head>
 <body>
 <div class="container">

--- a/binder/urls.py
+++ b/binder/urls.py
@@ -1,20 +1,22 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
+import django.contrib.auth.views
+import binder.views
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
 
-    url(r'^accounts/login/$', 'django.contrib.auth.views.login', name='login'),
-    url(r'^accounts/logout/$', 'django.contrib.auth.views.logout_then_login', name='logout'),
+    url(r'^accounts/login/$', django.contrib.auth.views.login, name='login'),
+    url(r'^accounts/logout/$', django.contrib.auth.views.logout_then_login, name='logout'),
 
-    url(r'^$', 'binder.views.home_index', name="index"),
-    url(r'^server_list/$', 'binder.views.view_server_list', name="server_list"),
+    url(r'^$', binder.views.home_index, name="index"),
+    url(r'^server_list/$', binder.views.view_server_list, name="server_list"),
 
-    url(r'^info/(?P<dns_server>[a-zA-Z0-9.-]+)/$', 'binder.views.view_server_zones', name="server_zone_list"),
-    url(r'^info/(?P<dns_server>[a-zA-Z0-9.-]+)/(?P<zone_name>[a-zA-Z0-9.-]+)/$', 'binder.views.view_zone_records', name="zone_list"),
+    url(r'^info/(?P<dns_server>[a-zA-Z0-9.-]+)/$', binder.views.view_server_zones, name="server_zone_list"),
+    url(r'^info/(?P<dns_server>[a-zA-Z0-9.-]+)/(?P<zone_name>[a-zA-Z0-9.-]+)/$', binder.views.view_zone_records, name="zone_list"),
 
-    url(r'^add_record/(?P<dns_server>[a-zA-Z0-9.-]+)/(?P<zone_name>[a-zA-Z0-9.-]+)/$', 'binder.views.view_add_record', name="add_record"),
-    url(r'^add_cname/(?P<dns_server>[a-zA-Z0-9.-]+)/(?P<zone_name>[a-zA-Z0-9.-]+)/(?P<record_name>.*?)/$', 'binder.views.view_add_cname_record', name="add_cname"),
-    url(r'^delete_record/(?P<dns_server>[a-zA-Z0-9.-]+)/(?P<zone_name>[a-zA-Z0-9.-]+)/$', 'binder.views.view_delete_record', name="delete_record"),
-)
+    url(r'^add_record/(?P<dns_server>[a-zA-Z0-9.-]+)/(?P<zone_name>[a-zA-Z0-9.-]+)/$', binder.views.view_add_record, name="add_record"),
+    url(r'^add_cname/(?P<dns_server>[a-zA-Z0-9.-]+)/(?P<zone_name>[a-zA-Z0-9.-]+)/(?P<record_name>.*?)/$', binder.views.view_add_cname_record, name="add_cname"),
+    url(r'^delete_record/(?P<dns_server>[a-zA-Z0-9.-]+)/(?P<zone_name>[a-zA-Z0-9.-]+)/$', binder.views.view_delete_record, name="delete_record"),
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django>=1.6
+Django>=1.8
 dnspython>=1.11
 pybindxml>=0.4

--- a/wsgi.py
+++ b/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for binder project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/
 """
 
 import os


### PR DESCRIPTION
This commit adds support for `Django 1.9`. As the template configuration options
changed with `Django 1.8` and versions earlier than 1.8 aren't supported anymore
anyway by upstream, support for them is removed.

To have the `Dockerfile` still working, this commit also changes its logic so the
dependencies get directly installed via the `requirements.txt` from PyPI, which
will ensure that always matching versions of all dependencies are present (e.g.
the Django version).

Building the Docker image will be broken until https://github.com/jforman/pybindxml/issues/15 is solved, as otherwise installing the obsolete `lxml` dependency fails.